### PR TITLE
Automatic deployment via GHA

### DIFF
--- a/.github/workflows/master_deploy.yml
+++ b/.github/workflows/master_deploy.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Deploy More repository
-      uses: SamKirkland/FTP-Deploy-Action@4.2.0
+      uses: SamKirkland/FTP-Deploy-Action@4.3.0
       with:
         server: ftp.tuxfamily.org
         username: ${{ secrets.GHA_MORE_FTP_USER }}

--- a/.github/workflows/master_deploy.yml
+++ b/.github/workflows/master_deploy.yml
@@ -1,0 +1,27 @@
+name: More repository Deploy
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build_site:
+    runs-on: ubuntu-20.04
+
+    name: Deploy "More" repository
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Deploy More repository
+      uses: SamKirkland/FTP-Deploy-Action@4.2.0
+      with:
+        server: ftp.tuxfamily.org
+        username: ${{ secrets.GHA_MORE_FTP_USER }}
+        password: ${{ secrets.GHA_MORE_FTP_PASS }}
+        local-dir: ./
+        server-dir: overte/more.overte.org-web/htdocs/
+        exclude: |
+          **/staging/**
+          **/.*
+          **/.*/**

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.secrets


### PR DESCRIPTION
This PR adds automatic deployment to more.overte.org
I have tested it locally via act. Once the DNS is configured, http://more.overte.org should already be working. Keep in mind that SSL takes up to 24 hours to start working.