### PR TITLE
Home App: Change the fallback to tutorial rather than localhost

### DIFF
--- a/applications/home/app_home.js
+++ b/applications/home/app_home.js
@@ -38,7 +38,7 @@
             if (LocationBookmarks.getHomeLocationAddress()) {
                 location.handleLookupString(LocationBookmarks.getHomeLocationAddress());
             } else {
-                location.goToLocalSandbox();
+                Window.location = "file:///~/serverless/tutorial.json";
             }
             button.editProperties({
                 isActive: false


### PR DESCRIPTION
When there is no home bookmark already set, the Home app was redirecting to localhost. But since there is a possibility that no localhost could be up and running, we will instead redirect to tutorial rather than to localhost. (tutorial being always present.)