### PR TITLE
Fix doppleganger height positioning issue

### DIFF
--- a/applications/doppelganger-mirror/doppleganger.js
+++ b/applications/doppelganger-mirror/doppleganger.js
@@ -172,7 +172,7 @@ Doppleganger.prototype = {
         }
 
         this.frame = 0;
-        this.position = options.position || Vec3.sum(avatar.position, Quat.getForward(avatar.orientation));
+        this.position = options.feetPosition || Vec3.sum(avatar.feetPosition, Quat.getForward(avatar.orientation));
         this.orientation = options.orientation || avatar.orientation;
         this.skeletonModelURL = avatar.skeletonModelURL;
         this.jointStateCount = 0;
@@ -189,7 +189,8 @@ Doppleganger.prototype = {
             visible: false, // normally false
             modelURL: this.skeletonModelURL, //was field: url
             position: this.position,
-            rotation: this.orientation
+            rotation: this.orientation,
+            useOriginalPivot: true
         };
 		
         this.entityID = Entities.addEntity(prop, "local");

--- a/tutorial/doppleganger.js
+++ b/tutorial/doppleganger.js
@@ -172,7 +172,7 @@ Doppleganger.prototype = {
         }
 
         this.frame = 0;
-        this.position = options.position || Vec3.sum(avatar.position, Quat.getForward(avatar.orientation));
+        this.position = options.feetPosition || Vec3.sum(avatar.feetPosition, Quat.getForward(avatar.orientation));
         this.orientation = options.orientation || avatar.orientation;
         this.skeletonModelURL = avatar.skeletonModelURL;
         this.jointStateCount = 0;
@@ -189,7 +189,8 @@ Doppleganger.prototype = {
             visible: false, // normally false
             modelURL: this.skeletonModelURL, //was field: url
             position: this.position,
-            rotation: this.orientation
+            rotation: this.orientation,
+            useOriginalPivot: true
         };
 		
         this.entityID = Entities.addEntity(prop, "local");


### PR DESCRIPTION
This PR fix the height positioning issue that appears after v8.

The doppleganger started to systematically appear above the ground:
![image](https://github.com/overte-org/community-apps/assets/60075796/71b6b948-cc87-4e41-8cb9-8ad8d770a67a)

Here once fixed:
![image](https://github.com/overte-org/community-apps/assets/60075796/9a1079f3-d076-407a-804b-fd4e0cb6f45d)
Instead to use **MyAvatar.position** and **useOriginalPivot = false (default)**, 
it uses now : **MyAvatar.feetPosition** and **useOriginalPivot = true**

This fixes the application and the modified version used in the tutorial.

