### PR TITLE
Fix initial position of the doppleganger in the Tutorial

### DIFF
--- a/tutorial/doppleganger.js
+++ b/tutorial/doppleganger.js
@@ -172,7 +172,7 @@ Doppleganger.prototype = {
         }
 
         this.frame = 0;
-        this.position = options.feetPosition || Vec3.sum(avatar.feetPosition, Quat.getForward(avatar.orientation));
+        this.position = options.position || Vec3.sum(avatar.feetPosition, Quat.getForward(avatar.orientation));
         this.orientation = options.orientation || avatar.orientation;
         this.skeletonModelURL = avatar.skeletonModelURL;
         this.jointStateCount = 0;


### PR DESCRIPTION
This PR should fix the initial position of the doppleganger in the Avatar Viewer in the Tutorial.
After the last fix for the feet height it stopped to render in the center of the avatar viewer platform.

This has not been tested. since it needs to be deployed to be able to test it. The script itself is called from a script in the Overte interface resource (not exposed in the resource folder) that would need a rebuild to be able to modify it just to test it.

Since this is not top critical, here is the procedure:
- Merge this (after review)
- Deploy this on the "more app" server
- Go in the tutorial and see that the avatar appear in the center and not next to the avatar,
![image](https://github.com/overte-org/community-apps/assets/60075796/a812367d-4f96-4faf-94e2-2c628d6b840d)
  
If it doesn't work as expected... 
... then we will have to fix over it again.
_(yeah, this is like building a boat in a bottle)_



