### PR TITLE
Fly Avatar app: Fix when the Fly Avatar is present at closure.

### DIFF
--- a/applications/flyAvatar/app-flyAvatar.js
+++ b/applications/flyAvatar/app-flyAvatar.js
@@ -26,6 +26,7 @@
     var INTERCALL_DELAY = 200; //0.3 sec
     var FLY_AVATAR_SETTING_KEY = "overte.application.more.flyAvatar.avatarUrl";
     var FLY_AVATAR_SWITCH_SETTING_KEY = "overte.application.more.flyAvatar.switch";
+    var FLY_AVATAR_ORIGINAL_AVATAR_SETTING_KEY = "overte.application.more.flyAvatar.originalAvatarUrl";
     var flyAvatarSwitch = true;
     var flyAvatarUrl = "";
     var originalAvatarUrl = "";
@@ -115,6 +116,7 @@
     MyAvatar.skeletonModelURLChanged.connect(function () {
         if (!MyAvatar.isFlying() && MyAvatar.skeletonModelURL !== flyAvatarUrl) {
             originalAvatarUrl = MyAvatar.skeletonModelURL;
+            Settings.setValue( FLY_AVATAR_ORIGINAL_AVATAR_SETTING_KEY, originalAvatarUrl);
         }
     });
 
@@ -173,6 +175,12 @@
     originalAvatarUrl = MyAvatar.skeletonModelURL;
     flyAvatarUrl = Settings.getValue( FLY_AVATAR_SETTING_KEY, "" );
     flyAvatarSwitch = Settings.getValue( FLY_AVATAR_SWITCH_SETTING_KEY, true );
+    if (originalAvatarUrl === flyAvatarUrl) {
+        var lastRecordedOriginalAvatar = Settings.getValue( FLY_AVATAR_ORIGINAL_AVATAR_SETTING_KEY, "" );
+        if (lastRecordedOriginalAvatar !== "") {
+            originalAvatarUrl = lastRecordedOriginalAvatar;
+        }
+    }
     if (flyAvatarSwitch) {
         inactiveIcon = APP_ICON_INACTIVE_ON;
     } else {


### PR DESCRIPTION
If we quit or crash or reload, if the fly avatar was used, the system keep it in its setting. 
So when we start, it bring the fly avatar when it was supposed to be the original. 
This fix addresses that.