### PR TITLE
Fix type error in flyAvatar 2

### DIFF
--- a/applications/flyAvatar/flyAvatar.html
+++ b/applications/flyAvatar/flyAvatar.html
@@ -28,7 +28,7 @@
                 messageObj = JSON.parse(message);
                 if (messageObj.channel === channel) {
                     if (messageObj.action === "FLY-AVATAR-URL") {
-                        flyAvatarUrl = messageObj.url;
+                        flyAvatarUrl = messageObj.url || [];
                         bookmarks = messageObj.bookmarks;
                         flyAvatarSwitch = messageObj.mainSwitch;
                         document.getElementById("mainSwitch").checked = flyAvatarSwitch;


### PR DESCRIPTION
Currently there is a type error in FlyAvatar.html that only occurs when there are no existing listing for avatars. This changes how flyAvatarUrl is set so that it is always the expected type 'array'. 