### PR TITLE
Disable nametags.js app from visibility

### DIFF
--- a/applications/metadata.js
+++ b/applications/metadata.js
@@ -82,7 +82,7 @@ var metadata = { "applications":
             "caption": "REFRESH"
         },
         {
-            "isActive": true,
+            "isActive": false,
             "directory": "nametags",
             "name": "Nametags",
             "description": "Display users' display names above their heads.",


### PR DESCRIPTION
Nametags.js has a large list of bugs that make using it sometimes challenging to use. As of release candidate 2024.07.1 this app is now completely unusable. The bug described in #85 now occurs at every attempted use. I think it would be wise to disable this app until these bugs can be properly addressed. 