### PR TITLE
[ Refresh-app ] Fix cache busting

### DIFF
--- a/applications/refresh-app/refreshApp.js
+++ b/applications/refresh-app/refreshApp.js
@@ -35,7 +35,7 @@ Script.scriptEnding.connect(function(){
 
 function refreshAvatar() {
     var modelURL = MyAvatar.getFullAvatarURLFromPreferences();
-    modelURL = modelURL.split("?")[0] + "?" + new Date().getTime();
+    modelURL = modelURL.split("#")[0] + "#" + new Date().getTime();
     MyAvatar.useFullAvatarURL(modelURL);
     console.log('Avatar refreshed: ' + modelURL);
 }
@@ -49,7 +49,7 @@ function refreshAttachments() {
     for (var id in data) {
         var attachment = data[id];
         if (attachment.type.toString() === 'Model') {
-            attachment.modelURL = attachment.modelURL.toString().split('?')[0] + '?' + Date.now();  
+            attachment.modelURL = attachment.modelURL.toString().split('#')[0] + '#' + Date.now();  
             attachmentAmount++;
         }
     }


### PR DESCRIPTION
The Refresh-app uses the query part of a url in order to take advantage of cache busting. This method does not seem to work with every server setup. This pull changes the part of the url that is used for cache busting to the fragment. 
In effect this changes the symbol from "?" to "#". 

Fixes #30.
This has a big "Works on my machine" disclaimer. Testing these changes will be highly appreciated. This has been tested against my private server, along with the Overte content server and the app appears to be functional. 