### PR TITLE
Spectator cam fixes

### DIFF
--- a/applications/spectator-camera/spectatorCamera.js
+++ b/applications/spectator-camera/spectatorCamera.js
@@ -92,9 +92,9 @@
             "position": cameraPosition,
             "shapeType": "simple-hull",
             "type": "Model",
-            "userData": "{\"grabbableKey\":{\"grabbable\":true}}",
+            "grab": {"grabbable": true},
             "isVisibleInSecondaryCamera": false
-        }, true);
+        }, Entities.canRezAvatarEntities() ? "avatar" : "local");
         spectatorCameraConfig.attachedEntityId = camera;
         createLocalEntity();
         if (!HMD.active) {
@@ -312,7 +312,7 @@
             dimensions: viewFinderLocalEntityDim,
             isVisibleInSecondaryCamera: false,
             ignorePickIntersection: true
-        }); //"local");
+        }, "local");
         var windowGeometry = [];
         windowGeometry.width = Window.innerWidth;
         windowGeometry.height = Window.innerHeight;
@@ -412,12 +412,12 @@
     //   -switchViewControllerMapping: The controller mapping itself.
     //   -takeSnapshotControllerMappingName: The name of the controller mapping.
     //   -takeSnapshotControllerMapping: The controller mapping itself.
-    //   -controllerType: "OculusTouch", "Vive", "Other".
+    //   -controllerType: "OculusTouch", "Vive", "OpenXR", "Other".
     var switchViewControllerMapping;
     var switchViewControllerMappingName = 'Hifi-SpectatorCamera-Mapping-SwitchView';
     function registerSwitchViewControllerMapping() {
         switchViewControllerMapping = Controller.newMapping(switchViewControllerMappingName);
-        if (controllerType === "OculusTouch") {
+        if (controllerType === "OculusTouch" || controllerType === "OpenXR") {
             switchViewControllerMapping.from(Controller.Standard.LS).to(function (value) {
                 if (value === 1.0) {
                     setMonitorShowsCameraViewAndSendToQml(!monitorShowsCameraView);
@@ -438,7 +438,7 @@
 
     var flash = false;
     function setFlashStatus(enabled) {
-        var cameraPosition = Entities.getEntityProperties(camera, ["positon"]).position;
+        var cameraPosition = Entities.getEntityProperties(camera, "position").position;
         if (enabled) {
             if (camera) {
                 Audio.playSound(SOUND_FLASH_ON, {
@@ -469,7 +469,7 @@
                     "name": "Camera Flash",
                     "type": "Light",
                     "parentID": camera,
-                }, true);
+                }, Entities.canRezAvatarEntities() ? "avatar" : "local");
             }
         } else {
             if (flash) {
@@ -529,12 +529,12 @@
             if (HMD.active && monitorShowsCameraView) {
                 setDisplay(false);
             }
-            Window.takeSecondaryCamera360Snapshot(Entities.getEntityProperties(camera, ["positon"]).position);
+            Window.takeSecondaryCamera360Snapshot(Entities.getEntityProperties(camera, "position").position);
         }
     }
     function registerTakeSnapshotControllerMapping() {
         takeSnapshotControllerMapping = Controller.newMapping(takeSnapshotControllerMappingName);
-        if (controllerType === "OculusTouch") {
+        if (controllerType === "OculusTouch" || controllerType === "OpenXR") {
             takeSnapshotControllerMapping.from(Controller.Standard.RS).to(function (value) {
                 if (value === 1.0) {
                     maybeTakeSnapshot();
@@ -558,6 +558,8 @@
                 controllerType = "Vive";
             } else if (VRDevices.indexOf("OculusTouch") !== -1) {
                 controllerType = "OculusTouch";
+            } else if (VRDevices.indexOf("OpenXR") !== -1) {
+                controllerType = "OpenXR";
             } else {
                 sendToQml({
                     method: 'updateControllerMappingCheckbox',


### PR DESCRIPTION
* Fixes the typo that broke 360 snapshots
* Adds OpenXR support to stick-click shortcuts
* Fall back to using local entities on domains that don't allow avatar entities

<img width="1024" height="512" alt="overte-snap-by-ada-tv-on-2025-08-13_15-40-14" src="https://github.com/user-attachments/assets/7f260416-6e05-409a-90a8-22ee2a30d288" />
<img width="640" height="480" alt="overte-snap-by-ada-tv-on-2025-08-13_16-05-24" src="https://github.com/user-attachments/assets/a59839e1-448a-486f-8f7f-3d3398dff45d" />