### PR TITLE
Nametags Optimisation

### DIFF
--- a/applications/nametags/nametags.js
+++ b/applications/nametags/nametags.js
@@ -150,11 +150,21 @@
     print("oldSessionUUID:", oldSessionUUID); // null if entering
 
     if (oldSessionUUID !== null) {
-        _removeUser(oldSessionUUID);
+        if (user_nametags[oldSessionUUID]) _removeUser(oldSessionUUID);
     }
 
     if (newSessionUUID !== null) {
-      _addUser(newSessionUUID);
+      // This is MyAvatar only if MyAvatar.sessionUUID matches either oldSessionUUID, newSessionUUID or "{00000000-0000-0000-0000-000000000001}"
+      const isSelf = [oldSessionUUID, "{00000000-0000-0000-0000-000000000001}", newSessionUUID].includes(MyAvatar.sessionUUID);
+
+      if (!isSelf){
+        _addUser(MyAvatar.sessionUUID);
+      } else if (newSessionUUID !== "{00000000-0000-0000-0000-000000000001}"
+          && visibleSelf
+          && !Camera.mode.includes("first person")) {
+            _addUser(newSessionUUID);
+            last_camera_mode = Camera.mode;
+      }
     }
   }
 

--- a/applications/nametags/nametags.js
+++ b/applications/nametags/nametags.js
@@ -355,7 +355,7 @@
       // We'll keep trying until textSize does not report 0.
       Script.setTimeout(() => {_adjustNametagSize(user_uuid)}, 100);
       return;
-    } else if (textSize.height <= 0.0001
+    } else if (textSize.height <= 0.08
             || textSize.height >= 0.2
             || textSize.height === null) {
       // Text size returns unexpected values during entity

--- a/applications/nametags/nametags.js
+++ b/applications/nametags/nametags.js
@@ -22,6 +22,9 @@
   const COLOUR_DISABLED = "red";
   const COLOUR_INACTIVE = [128, 128, 128];
 
+  const MENU_VISIBLE_MENU = "View";
+  const MENU_VISIBLE_NAME = "Nametags";
+
   _updateList();
 
   AvatarManager.avatarAddedEvent.connect(_addUser); // New user connected
@@ -30,7 +33,7 @@
   Script.update.connect(_adjustNametags); // Delta time
 
   Script.scriptEnding.connect(_scriptEnding); // Script was uninstalled
-  Menu.menuItemEvent.connect(_toggleState); // Toggle the nametag
+  Menu.menuItemEvent.connect(_handleMenuClick); // Toggle the nametag
 
   // Messages
   Messages.subscribe(CHANNEL_CLICK_CONTEXT);
@@ -48,8 +51,8 @@
 
   // Menu item
   Menu.addMenuItem({
-    menuName: "View",
-    menuItemName: "Nametags",
+    menuName: MENU_VISIBLE_MENU,
+    menuItemName: MENU_VISIBLE_NAME,
     shortcutKey: "CTRL+N",
     isCheckable: true,
     isChecked: visible,
@@ -165,6 +168,12 @@
             _addUser(newSessionUUID);
             last_camera_mode = Camera.mode;
       }
+    }
+  }
+
+  function _handleMenuClick(menuItem) {
+    if (MENU_VISIBLE_NAME === menuItem) {
+      _toggleState();
     }
   }
 
@@ -443,7 +452,7 @@
 
   function _scriptEnding() {
     tablet.removeButton(tabletButton);
-    Menu.removeMenuItem("View", "Nametags");
+    Menu.removeMenuItem(MENU_VISIBLE_MENU, MENU_VISIBLE_NAME);
 
     for (let i = 0; Object.keys(user_nametags).length > i; i++) {
       Entities.deleteEntity(user_nametags[Object.keys(user_nametags)[i]].text);

--- a/applications/nametags/nametags.js
+++ b/applications/nametags/nametags.js
@@ -65,17 +65,17 @@
   const actionSet = [
     {
       text: textToggle(visible)+" Nametags",
- localClickFunc: "nametags.toggle",
- textColor: textColour(visible),
- priority: -5,
+      localClickFunc: "nametags.toggle",
+      textColor: textColour(visible),
+      priority: -5,
     },
     {
       text: textToggle(visibleSelf)+" My Nametag",
- localClickFunc: "nametags.toggleSelf",
- textColor: visible ?
- textColour(visibleSelf)
- : COLOUR_INACTIVE,
- priority: -4.9,
+      localClickFunc: "nametags.toggleSelf",
+      textColor: visible ?
+      textColour(visibleSelf)
+      : COLOUR_INACTIVE,
+      priority: -4.9,
     },
   ];
 

--- a/applications/nametags/nametags.js
+++ b/applications/nametags/nametags.js
@@ -339,6 +339,8 @@
         text: display_name,
       });
       user_nametags[user_uuid].displayName = newName;
+      // Adjust nametag size to accomodate new displayName
+      _adjustNametagSize(user_uuid);
     }
   }
 

--- a/applications/nametags/nametags.js
+++ b/applications/nametags/nametags.js
@@ -337,13 +337,26 @@
   // Resize user's nametag entity
   function _adjustNametagSize(user_uuid) {
     const user = AvatarList.getAvatar(user_uuid);
-    let textSize = Entities.textSize(user_nametags[user_uuid].text, _displayName(user));
+    const display_name = _displayName(user);
+    let textSize = Entities.textSize(user_nametags[user_uuid].text, display_name);
 
     if (textSize.width === 0 || textSize.height === 0) {
       // Text size cannot be calculated immediately after entity creation;
       // We'll keep trying until textSize does not report 0.
       Script.setTimeout(() => {_adjustNametagSize(user_uuid)}, 100);
       return;
+    } else if (textSize.height <= 0.0001
+            || textSize.height >= 0.2
+            || textSize.height === null) {
+      // Text size returns unexpected values during entity
+      // creation. When entity sizes are too large, too small
+      // or invalid we ignore them.
+      // See https://github.com/overte-org/overte/issues/1897.
+      print(`!!! Text size for ${display_name} is an unexpected ${JSON.stringify(textSize)}; Not sizing yet.`);
+      Script.setTimeout(() => {_adjustNametagSize(user_uuid)}, 100);
+      return;
+    } else {
+      print(`Text size for ${display_name} is ${JSON.stringify(textSize)}`);
     }
 
     Entities.editEntity(user_nametags[user_uuid].text,

--- a/applications/nametags/nametags.js
+++ b/applications/nametags/nametags.js
@@ -389,10 +389,12 @@
 
   // Remove a user from the user list
   function _removeUser(user_uuid) {
-    console.log(`Deleting ${user_uuid} nametag`);
-    Entities.deleteEntity(user_nametags[user_uuid].text);
-    Entities.deleteEntity(user_nametags[user_uuid].background);
-    delete user_nametags[user_uuid];
+    if (user_nametags[user_uuid]) {
+      console.log(`Deleting ${user_uuid} nametag`);
+      Entities.deleteEntity(user_nametags[user_uuid].text);
+      Entities.deleteEntity(user_nametags[user_uuid].background);
+      delete user_nametags[user_uuid];
+    }
   }
 
   // Enable or disable nametags


### PR DESCRIPTION
Optimised nametags so they are not modifiying each nametag entity 60/s

They will now only update nametags in response to the following:

- Avatar scaling
- Avatar name change
- Avatar sessionUUID changes (typically when travelling to a new Place)
- Avatar URL change

Adds toggles to context menu, including the option to show own nametag (defaults: false)

Also fixes the following issues:

* Name tag height was sometimes the wrong height, often much too short appearing partially cutoff
* Resolves #82 
* Resolves #83
* Nametags toggle visibility when non-nametag menu items are clicked

And some minor refactoring, including rearranging functions.